### PR TITLE
Remove warning message

### DIFF
--- a/src/hex/compiletime/flow/modular/FlowLibCompiler.hx
+++ b/src/hex/compiletime/flow/modular/FlowLibCompiler.hx
@@ -94,7 +94,6 @@ class FlowLibCompiler
 				.map( formatMatch )
 				.join(',');
 
-			haxe.macro.Context.warning( 'Modular registering: $libName=$pattern', haxe.macro.Context.currentPos() );
 			MySplit.register( '$libName=$pattern' );
 	}
 	


### PR DESCRIPTION
It's annoying to see ~25 identical cryptic warnings in every build